### PR TITLE
Add Jupyter4NFDI ; Update Jupyter-JSC

### DIFF
--- a/data/jupyter-jsc.fz-juelich.de.yaml
+++ b/data/jupyter-jsc.fz-juelich.de.yaml
@@ -1,19 +1,20 @@
 title: Jupyter-JSC
 provider: Juelich Supercomputing Centre
-service_url: https://jupyter-jsc.fz-juelich.de
+service_url: https://jupyter.jsc.fz-juelich.de
+health_api_url: https://jupyter.jsc.fz-juelich.de/hub/api
 support: ds-support@fz-juelich.de
 health_api_url: 
-documentation_url: https://docs.jupyter-jsc.fz-juelich.de
+documentation_url: https://docs.jupyter.jsc.fz-juelich.de
 target_group_open_for: HPC users of JSC. Helmholtz users in general
 restricted: true
 login_process: Login via JSC account or Helmholtz AAI
 features:
-  version: JupyterHub 2.3.1; JupyterLab 2.6,3.2,3.3,3.4
+  version: JupyterHub 4.1.5; JupyterLab 3.6, 4.2, users may start their own docker images
   programming_languages: ["Bash", "Cling", "JavaScript", "Julia", "Octave", "R", "Ruby"]
   environments: ["PyDeepLearning", "PyQuantum", "PyVisualization", "Custom"]
   environments_info: "https://docs.jupyter-jsc.fz-juelich.de/github/FZJ-JSC/jupyter-jsc-notebooks/blob/documentation/02-Configuration/01-Kernels&Proxies.ipynb"
   extensions: ["Bokeh", "JupyterLab Preview", "JupyterLab Manager", "JupyterLab Sidecar", "JupyterLab Git", "JupyterLab server proxy", "JupyterLab toc", "JupyterLab lsp", "JupyterLab quickopen", "JupyterLab pyviz", "JupyterLab Code Formatter", "BQPlot", "Dask Labextension", "IPyVolume", "ITKWidgets", "Leaflet", "Matplotlib", "ThreeJS", "Vue", "Vuetify", "JuypterLab Control", "JupyterLab Dash", "JupyterLab Datawidgets", "JupyterLab GitLab", "JupyterLab Lmod", "JupyterLab plotly", "JupyterLab System Monitor", "JupyterLAb Theme Toggle", "JupyterLab topbar extension", "JupyterLab iframe", "nbdime", "plotlywidget", "pvlink", "Jupyter Slurm Provisioner", "NVDashboard"]
-  proxy_apps: ["XPra"]
+  proxy_apps: ["XPra", "NESTDesktop", "MatLab", "RStudio"]
   install: true
   shared_folder: false
   persistent_storage: true

--- a/data/jupyter4nfdi.yaml
+++ b/data/jupyter4nfdi.yaml
@@ -1,0 +1,100 @@
+# Service name. If too general, should include a provider or project context.
+title: Jupyter4NFDI
+# All service providers
+provider: Juelich Supercomputing Centre
+# Link address to the entrypoint for users
+service_url: https://hub.nfdi-jupyter.de
+# If the service_url is not public available, the requirements to reach it
+# Email address where to get help
+support: ds-support@fz-juelich.de
+# Healthcheck URL
+health_api_url: https://hub.nfdi-jupyter.de/hub/api
+# Service specific documentation for users
+documentation_url: https://docs.jupyter.jsc.fz-juelich.de
+# Roles, domain, NFDI consortia, University, etc.
+target_group_open_for: Users within NFDI
+# Whether any researcher in Germany can use the service (true / false)
+restricted: true
+# How is the login performed; Login-URL
+login_process: Login via Helmholtz AAI. IAM4NFDI integration in the future.
+features: # What the service offers.
+  # version of JupyterHub; classic notebook or lab view?
+  version: 4.1.5; JupyterLab 4.2, users may start their own docker images
+  # List of supported programming languages (kernels)
+  programming_languages: ["Python", "Bash", "Cling", "JavaScript", "Julia", "Octave", "R", "Ruby"]
+  # List of supported environments (e.g., Python virtualenv) configured as kernels
+  environments: ["CreateYourOwnKernel", "PyDeepLearning", "PyQuantum", "PyVisualization"]
+  # Link to information about the supported environments, if not included under documentation_url
+  # List of pre-installed JupyterHub extensions
+  extensions: ["Bokeh", "JupyterLab Preview", "JupyterLab Manager", "JupyterLab Sidecar", "JupyterLab Git", "JupyterLab server proxy", "JupyterLab toc", "JupyterLab lsp", "JupyterLab quickopen", "JupyterLab pyviz", "JupyterLab Code Formatter", "BQPlot", "Dask Labextension", "IPyVolume", "ITKWidgets", "Leaflet", "Matplotlib", "ThreeJS", "Vue", "Vuetify", "JuypterLab Control", "JupyterLab Dash", "JupyterLab Datawidgets", "JupyterLab GitLab", "JupyterLab Lmod", "JupyterLab plotly", "JupyterLab System Monitor", "JupyterLAb Theme Toggle", "JupyterLab topbar extension", "JupyterLab iframe", "nbdime", "plotlywidget", "pvlink", "Jupyter Slurm Provisioner", "NVDashboard"]
+  # List of server-proxy featured applications
+  proxy_apps: ["XPra", "NESTDesktop", "RStudio"]
+  # Whether it is allowed to install further packages, kernels, extensions (true / false)
+  install: true
+  # Whether there is a folder to share documents with others (true / false)
+  shared_folder: false
+  # Whether files can survive the docker session (true / false)
+  persistent_storage: true
+  # List of other features you find relevant
+  misc: []
+technicals: # Information about the technology stack used
+  # The underlying system below JupyterHub, e.g., HPC, Openstack
+  platform: OpenStack
+  # The way Jupyter is installed on the system, e.g., Docker, Kubernetes
+  deployment: Kubernetes
+  # Link to more (technical) information or a (Git) repository about the deployment or other administration tasks
+  deployment_url: https://github.com/FZJ-JSC/jupyter-jsc-deployment/
+  # List of required attributes, entitlements or memberships for login
+  login_attributes: []
+  # Where the resources (compute / storage) are located
+  hardware_location: JSC, others will follow
+  # List of other technicals you find relevant
+  misc: []
+resources: # Information about available resources on the instance
+  # Default number of Jupyter servers per user
+  default_server_user: 1
+  # Maximum number of Jupyter servers per user
+  max_server_user: 5
+  # Default number of CPU for a Jupyter server
+  default_cpu: 1
+  # Maximum number of CPU for a Jupyter server
+  max_cpu: 2
+  # Guarantied total number of CPUs for the whole Jupyterhub instance
+  total_cpu: 96
+  # Scaled total number of CPUs for the whole JupyterHub instance. Normally not exclusive, depends on other factors.
+  burst_total_cpu: 192
+  # Default CPU time for a Jupyter server
+  default_cpu_time: 5 days
+  # Maximum CPU time for a Jupyter server
+  max_cpu_time: 5 days
+  # Default amount of memory for a Jupyter server
+  default_memory: 2 GB
+  # Maximum amount of memory for a Jupyter server
+  max_memory: 8 GB
+  # Guarantied total amount of memory for the whole Jupyterhub instance
+  total_memory: 192 GB
+  # Scaled total amount of memory for the whole JupyterHub instance. Normally not exclusive, depends on other factors.
+  burst_total_memory: 384 GB
+  # Default number of GPU for a Jupyter server
+  default_gpu: 0
+  # Maximum number of GPU for a Jupyter server
+  max_gpu: 0
+  # Guarantied total number of GPUs for the whole Jupyterhub instance
+  total_gpu: 0
+  # Scaled total number of GPUs for the JupyterHub instance. Normally not exclusive, depends on other factors.
+  burst_total_gpu: 0
+  # Default amount of disk space (maybe temporary) for a Jupyter server
+  default_disk: 25 GB
+  # Maximum amount of disk space (maybe temporary) for a Jupyter server
+  max_disk: 25 GB
+  # Default amount of disk space that survives a Jupyter session
+  default_persistent_disk: 25 GB
+  # Maximum amount of disk space that survives a Jupyter session
+  max_persistent_disk: 25 GB
+  # Guarantied total amount of disk space for the whole Jupyterhub instance
+  total_disk: 1 TB
+  # Scaled total amount of disk space for the whole JupyterHub instance. Normally not exclusive, depends on other factors.
+  burst_total_disk: 1 TB
+#usage: # Statistical information about the Jupyterhub instance
+  # Average number of Jupyter sessions per day
+  #average_daily_sessions: 


### PR DESCRIPTION
This PR should add the the Jupyter4NFDI instance ( https://hub.nfdi-jupyter.de ) to this list.

It also includes a few small Jupyter-JSC updates